### PR TITLE
Correct inflight events when pipeline is unhealthy

### DIFF
--- a/check_logstash
+++ b/check_logstash
@@ -3,14 +3,15 @@
 # File : check_logstash
 # Author : Thomas Widhalm, Netways
 # E-Mail: thomas.widhalm@netways.de
-# Date : 11/04/2019
+# Date : 19/04/2021
 #
-# Version: 0.7.3-0
+# Version: 0.7.4-0
 #
 # This program is free software; you can redistribute it or modify
 # it under the terms of the GNU General Public License version 3.0
 #
 # Changelog:
+#   - 0.7.4 fix inflight event calculation when pipeline is not healthy
 #   - 0.7.3 fix inflight event calculation
 #   - 0.7.2 fix handling of xpack-monitoring pipeline
 #   - 0.7.1 fix multipipeline checks, improve errorhandling
@@ -435,10 +436,15 @@ class CheckLogstash
 
       for named_pipeline in result.get('pipelines') do
         if named_pipeline[0] != ".monitoring-logstash"
+          res = result.get('pipelines.' + named_pipeline[0])
+          if !res['events'].include?('in')
+            puts "CRITICAL: No in inflight events for #{named_pipeline[0]}, pipeline seems unhealthy"
+            exit(3)
+          end
           events_in = result.get('pipelines.' + named_pipeline[0] + '.events.in').to_i
           events_out = result.get('pipelines.' + named_pipeline[0] + '.events.out').to_i
 
-          inflight_events = events_in - events_out
+          inflight_events = (events_in - events_out).abs
           inflight_events_report = inflight_events_report + " " + named_pipeline[0] + ": " + inflight_events.to_s + ";"
 
           if critical_inflight_events_max && critical_inflight_events_max < inflight_events
@@ -457,7 +463,7 @@ class CheckLogstash
       if critical_counter > 0
         Critical.new(inflight_events_report)
       elsif warn_counter > 0
-        Warning.new(infligh_events_report)
+        Warning.new(inflight_events_report)
       else
         OK.new(inflight_events_report)
       end


### PR DESCRIPTION
When pipeline is unhealthy, the "in" events counter does not exists.

Signed-off-by: Rémi VERCHERE <remi.verchere@axians.com>