### PR TITLE
Add option to monitor single pipelines and to monitor events in/out per minute.

### DIFF
--- a/contrib/icinga2-commands.conf
+++ b/contrib/icinga2-commands.conf
@@ -46,6 +46,26 @@ object CheckCommand "logstash" {
 			value = "$logstash_cpu_crit$"
 			description = "Critical threshold for cpu usage in percent"
 		}
+		"--temp-filedir" = {
+			value = "$logstash_temp_filedir$"
+			description = "Directory to use for the temporary state file. Only used when one of the events-per-minute metrics is used. Defaults to /tmp"
+		}
+		"--events-in-per-minute-warn" = {
+            value = "$logstash_events_in_per_minute_warn$"
+            description = "Threshold for the number of ingoing events per minute to be a warning. Use min:max for a range."
+        }
+        "--events-in-per-minute-crit" = {
+            value = "$logstash_events_in_per_minute_crit$"
+            description = "Threshold for the number of ingoing events per minute to be critical. Use min:max for a range."
+        }
+        "--events-out-per-minute-warn" = {
+            value = "$logstash_events_out_per_minute_warn$"
+            description = "Threshold for the number of outgoing events per minute to be a warning. Use min:max for a range."
+        }
+        "--events-out-per-minute-crit" = {
+            value = "$logstash_events_out_per_minute_crit$"
+            description = "Threshold for the number of outgoing events per minute to be critical. Use min:max for a range."
+        }
 
 	}
 	vars.logstash_hostname = "$check_address$"

--- a/contrib/icinga2-commands.conf
+++ b/contrib/icinga2-commands.conf
@@ -10,6 +10,10 @@ object CheckCommand "logstash" {
 			value = "$logstash_port$"
 			description = "Port where Logstash is listening for API requests"
 		}
+		"-P" = {
+            value = "$logstash_pipeline$"
+            description = "If set, check the given pipeline only"
+        }
 		"--file-descriptor-threshold-warn" = {
 			value = "$logstash_filedesc_warn$"
 			description = "Warning threshold of file descriptor usage in percent"

--- a/lib/check_logstash.rb
+++ b/lib/check_logstash.rb
@@ -3,7 +3,7 @@
 # File : check_logstash
 # Author : Thomas Widhalm, Netways
 # E-Mail: thomas.widhalm@netways.de
-# Date : 11/04/2019
+# Date : 18/07/2022
 #
 # Version: 0.8.0-0
 #


### PR DESCRIPTION
Hi,
we wanted to have extended features for this plugin for our use case, which includes:

- Possibility to monitor only one single pipeline
- Possibility to monitor the incoming/outgoing events on a per minute base. 

We especially wanted the events per minute metrics, since our inflight events were zero very often. The new metrics allow us to see that events are processed by checking if the events in/out per minute is above zero.

Other smaller adjustments
- Thresholds can now be correctly given where only min: is used
- Refactoring to have less code

I didn't touch the plugin in the root directly. I thought that it will get automatically replaced via rake.