### PR TITLE
Add Logstash 6 compatibility for health check

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -180,6 +180,16 @@ var healthCmd = &cobra.Command{
 			check.ExitError(err)
 		}
 
+		// Enable some backwards compatibility
+		// Can be changed to a switch statement in the future,
+		// when more versions need special cases
+		// For Logstash 6, we assume a parsed JSON response
+		// is enough to declare the instance running, since there
+		// is no status field.
+		if stat.MajorVersion == 6 {
+			stat.Status = "green"
+		}
+
 		// Logstash Health Status
 		switch stat.Status {
 		default:


### PR DESCRIPTION
While Logstash 6 is no longer supported by Elastic, it wasn't a big change in the codebase to still support it here.

And we might need some code for  backwards compatibility in the future anyways. 

Fixes #63 