### PR TITLE
Add check for pipeline configuration reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ Flags:
   -h, --help                          help for pipeline
 ```
 
+### Pipeline Reload
+
+Checks the status of Logstash pipelines configuration reload.
+
+```bash
+Usage:
+  check_logstash pipeline reload [flags]
+
+Examples:
+
+	$ check_logstash pipeline reload
+	OK - Configuration successfully reloaded
+	 \_[OK] Configuration successfully reloaded for pipeline Foobar for on 2021-01-01T02:07:14Z
+
+	$ check_logstash pipeline reload --pipeline Example
+	CRITICAL - Configuration reload failed
+	 \_[CRITICAL] Configuration reload for pipeline Example failed on 2021-01-01T02:07:14Z
+
+Flags:
+  -P, --pipeline string               Pipeline Name (default "/")
+  -h, --help                          help for pipeline
+```
 
 ## License
 

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -117,6 +117,51 @@ func TestPipelineCmd_Logstash8(t *testing.T) {
 			args:     []string{"run", "../main.go", "pipeline", "--inflight-events-warn", "200", "--inflight-events-crit", "500"},
 			expected: "OK - Inflight events",
 		},
+		{
+			name: "pipeline-reload-no-success",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"host":"localhost","version":"8.6","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"localhost-input":{"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"plugins":{"inputs":[{"id":"b","name":"beats","events":{"queue_push_duration_in_millis":0,"out":0}}],"codecs":[{"id":"plain","name":"plain","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}},{"id":"json","name":"json","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}}],"filters":[],"outputs":[{"id":"f","name":"redis","events":{"duration_in_millis":18,"out":50,"in":100}}]},"reloads":{"successes":0,"last_success_timestamp":"","last_error":null,"last_failure_timestamp":"2020-10-11T01:10:10.11Z","failures":0},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "reload"},
+			expected: "UNKNOWN - Configuration reload status unknown",
+		},
+		{
+			name: "pipeline-reload-not-timestamp",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"host":"localhost","version":"8.6","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"localhost-input":{"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"plugins":{"inputs":[{"id":"b","name":"beats","events":{"queue_push_duration_in_millis":0,"out":0}}],"codecs":[{"id":"plain","name":"plain","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}},{"id":"json","name":"json","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}}],"filters":[],"outputs":[{"id":"f","name":"redis","events":{"duration_in_millis":18,"out":50,"in":100}}]},"reloads":{"successes":0,"last_success_timestamp":"not a timestamp","last_error":null,"last_failure_timestamp":"no time for you","failures":0},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "reload"},
+			expected: "[UNKNOWN] Configuration reload for pipeline",
+		},
+		{
+			name: "pipeline-reload-failed",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"host":"localhost","version":"8.6","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"localhost-input":{"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"plugins":{"inputs":[{"id":"b","name":"beats","events":{"queue_push_duration_in_millis":0,"out":0}}],"codecs":[{"id":"plain","name":"plain","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}},{"id":"json","name":"json","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}}],"filters":[],"outputs":[{"id":"f","name":"redis","events":{"duration_in_millis":18,"out":50,"in":100}}]},"reloads":{"successes":0,"last_success_timestamp":"2020-10-11T01:10:10.11Z","last_error":null,"last_failure_timestamp":"2021-10-11T01:10:10.11Z","failures":0},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "reload"},
+			expected: "[CRITICAL] Configuration reload for pipeline localhost-input",
+		},
+		{
+			name: "pipeline-reload-ok",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"host":"localhost","version":"8.6","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"localhost-input":{"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"plugins":{"inputs":[{"id":"b","name":"beats","events":{"queue_push_duration_in_millis":0,"out":0}}],"codecs":[{"id":"plain","name":"plain","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}},{"id":"json","name":"json","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}}],"filters":[],"outputs":[{"id":"f","name":"redis","events":{"duration_in_millis":18,"out":50,"in":100}}]},"reloads":{"successes":0,"last_success_timestamp":"2020-10-11T01:10:10.11Z","last_error":null,"last_failure_timestamp":"2019-10-11T01:10:10.11Z","failures":0},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "reload"},
+			expected: "[OK] Configuration successfully reloaded for pipeline localhost-input",
+		},
+		{
+			name: "pipeline-reload-missing",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"path": "/_node/stats/pipelines/foo","status": 404,"error": {"message": "Not Found"}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "reload", "--pipeline", "foo"},
+			expected: "UNKNOWN - Could not get",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/logstash/api.go
+++ b/internal/logstash/api.go
@@ -13,8 +13,10 @@ type Pipeline struct {
 	Host      string `json:"host"`
 	Pipelines map[string]struct {
 		Reloads struct {
-			Successes int `json:"successes"`
-			Failures  int `json:"failures"`
+			LastSuccessTime string `json:"last_success_timestamp"`
+			LastFailureTime string `json:"last_failure_timestamp"`
+			Successes       int    `json:"successes"`
+			Failures        int    `json:"failures"`
 		} `json:"reloads"`
 		Queue struct {
 			Type                string `json:"type"`


### PR DESCRIPTION
Adds new subcheck for pipelines to validate the last successful reload time.

I thought using a subcheck was a cleaner solution than to mix it with the inflight event checks.

Fixes #49 

Code can be optimized in the future, there is some duplication. But better than wrongs abstraction.

Examples:

```
$ check_logstash pipeline reload
OK - Configuration successfully reloaded
 \_[OK] Configuration successfully reloaded for pipeline Foobar for on 2021-01-01T02:07:14Z

$ check_logstash pipeline reload --pipeline Example
CRITICAL - Configuration reload failed
 \_[CRITICAL] Configuration reload for pipeline Example failed on 2021-01-01T02:07:14Z
```