### PR TITLE
Add Flow Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Flags:
 
 ### Pipeline
 
-Checks the status of Logstash pipelines.
+Determines the health of Logstash pipelines via "inflight events". These events are calculated as such: `inflight events = events.In - events.Out`
+
+Hint: Use the queue backpressure for Logstash 8.
 
 ```bash
 Usage:
@@ -84,6 +86,34 @@ Flags:
       --inflight-events-warn string   Warning threshold for inflight events to be a warning result. Use min:max for a range.
       --inflight-events-crit string   Critical threshold for inflight events to be a critical result. Use min:max for a range.
   -h, --help                          help for pipeline
+```
+
+### Pipeline Flow Metrics
+
+Checks the status of a Logstash pipeline's flow metrics (currently queue backpressure).
+
+Hint: Requires Logstash 8.5.0
+
+```bash
+
+Usage:
+  check_logstash pipeline flow [flags]
+
+Examples:
+
+	$ check_logstash pipeline flow --warning 5 --critical 10
+	OK - Flow metrics alright
+	 \_[OK] queue_backpressure_example:0.34;
+
+	$ check_logstash pipeline flow --pipeline example --warning 5 --critical 10
+	CRITICAL - Flow metrics alright
+	 \_[CRITICAL] queue_backpressure_example:11.23;
+
+Flags:
+  -c, --critical string   Critical threshold for queue Backpressure
+  -h, --help              help for flow
+  -P, --pipeline string   Pipeline Name (default "/")
+  -w, --warning string    Warning threshold for queue Backpressure
 ```
 
 ### Pipeline Reload

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -162,6 +162,24 @@ func TestPipelineCmd_Logstash8(t *testing.T) {
 			args:     []string{"run", "../main.go", "pipeline", "reload", "--pipeline", "foo"},
 			expected: "UNKNOWN - Could not get",
 		},
+		{
+			name: "pipeline-flow-ok",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"host":"foobar","version":"8.7.1","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"ansible-input":{"flow":{"queue_backpressure":{"current":12.34,"last_1_minute":0,"lifetime":2.503e-05},"output_throughput":{"current":0,"last_1_minute":0.344,"lifetime":0.7051},"input_throughput":{"current":10,"last_1_minute":0.5734,"lifetime":1.089},"worker_concurrency":{"current":0.0001815,"last_1_minute":0.0009501,"lifetime":0.003384},"filter_throughput":{"current":0,"last_1_minute":0.5734,"lifetime":1.089}},"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "flow", "--warning", "15", "--critical", "20"},
+			expected: "[OK] queue_backpressure_ansible-input:12.34; | pipelines.queue_backpressure_ansible-input=12.34;15;20 pipelines.ansible-input.output_throughput=0 pipelines.ansible-input.input_throughput=10 pipelines.ansible-input.filter_throughput=0",
+		},
+		{
+			name: "pipeline-flow-critical",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"host":"foobar","version":"8.7.1","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"ansible-input":{"flow":{"queue_backpressure":{"current":10,"last_1_minute":0,"lifetime":2.503e-05},"output_throughput":{"current":0,"last_1_minute":0.344,"lifetime":0.7051},"input_throughput":{"current":10,"last_1_minute":0.5734,"lifetime":1.089},"worker_concurrency":{"current":0.0001815,"last_1_minute":0.0009501,"lifetime":0.003384},"filter_throughput":{"current":0,"last_1_minute":0.5734,"lifetime":1.089}},"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`))
+			})),
+			args:     []string{"run", "../main.go", "pipeline", "flow", "--warning", "1", "--critical", "2"},
+			expected: "CRITICAL - Flow metrics not alright",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/logstash/api.go
+++ b/internal/logstash/api.go
@@ -18,6 +18,12 @@ type Pipeline struct {
 			Successes       int    `json:"successes"`
 			Failures        int    `json:"failures"`
 		} `json:"reloads"`
+		Flow struct {
+			QueueBackpressure FlowMetric `json:"queue_backpressure"`
+			OutputThroughput  FlowMetric `json:"output_throughput"`
+			InputThroughput   FlowMetric `json:"input_throughput"`
+			FilterThroughput  FlowMetric `json:"filter_throughput"`
+		} `json:"flow"`
 		Queue struct {
 			Type                string `json:"type"`
 			EventsCount         int    `json:"events_count"`
@@ -32,6 +38,12 @@ type Pipeline struct {
 			Out               int `json:"out"`
 		} `json:"events"`
 	} `json:"pipelines"`
+}
+
+type FlowMetric struct {
+	Current     float64 `json:"current"`
+	Last1Minute float64 `json:"last_1_minute"`
+	Lifetime    float64 `json:"lifetime"`
 }
 
 type Process struct {

--- a/internal/logstash/api_test.go
+++ b/internal/logstash/api_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestUmarshallPipelineFlow(t *testing.T) {
+
+	j := `{"host":"foobar","version":"8.7.1","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"ansible-input":{"flow":{"queue_backpressure":{"current":10,"last_1_minute":0,"lifetime":2.503e-05},"output_throughput":{"current":0,"last_1_minute":0.344,"lifetime":0.7051},"input_throughput":{"current":10,"last_1_minute":0.5734,"lifetime":1.089},"worker_concurrency":{"current":0.0001815,"last_1_minute":0.0009501,"lifetime":0.003384},"filter_throughput":{"current":0,"last_1_minute":0.5734,"lifetime":1.089}},"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"plugins":{"inputs":[{"id":"b","name":"beats","events":{"queue_push_duration_in_millis":0,"out":0}}],"codecs":[{"id":"plain","name":"plain","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}},{"id":"json","name":"json","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}}],"filters":[],"outputs":[{"id":"f","name":"redis","events":{"duration_in_millis":18,"out":50,"in":100}}]},"reloads":{"successes":0,"last_success_timestamp":null,"last_error":null,"last_failure_timestamp":null,"failures":0},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`
+
+	var pl Pipeline
+	err := json.Unmarshal([]byte(j), &pl)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if pl.Pipelines["ansible-input"].Flow.QueueBackpressure.Current != 10 {
+		t.Error("\nActual: ", pl.Pipelines["ansible-input"].Flow.QueueBackpressure.Current, "\nExpected: ", "10")
+	}
+
+	if pl.Pipelines["ansible-input"].Flow.InputThroughput.Current != 10 {
+		t.Error("\nActual: ", pl.Pipelines["ansible-input"].Flow.InputThroughput.Current, "\nExpected: ", "10")
+	}
+}
+
 func TestUmarshallPipeline(t *testing.T) {
 
 	j := `{"host":"foobar","version":"7.17.8","http_address":"127.0.0.1:9600","id":"4","name":"test","ephemeral_id":"5","status":"green","snapshot":false,"pipeline":{"workers":2,"batch_size":125,"batch_delay":50},"pipelines":{"ansible-input":{"events":{"filtered":0,"duration_in_millis":0,"queue_push_duration_in_millis":0,"out":50,"in":100},"plugins":{"inputs":[{"id":"b","name":"beats","events":{"queue_push_duration_in_millis":0,"out":0}}],"codecs":[{"id":"plain","name":"plain","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}},{"id":"json","name":"json","decode":{"writes_in":0,"duration_in_millis":0,"out":0},"encode":{"writes_in":0,"duration_in_millis":0}}],"filters":[],"outputs":[{"id":"f","name":"redis","events":{"duration_in_millis":18,"out":50,"in":100}}]},"reloads":{"successes":0,"last_success_timestamp":null,"last_error":null,"last_failure_timestamp":null,"failures":0},"queue":{"type":"memory","events_count":0,"queue_size_in_bytes":0,"max_queue_size_in_bytes":0},"hash":"f","ephemeral_id":"f"}}}`


### PR DESCRIPTION
Adds the Logstash 8.5.0 Flow Metrics to the Plugin.

Design:

```
check_logstash pipeline flow --pipeline foo --warning 1 --critical 2

 CRITICAL - Flow metrics not alright 
   \_[CRITICAL] queue_backpressure_foo:10.00;
 exit status 2

 OK - Flow metrics alright 
   \_[OK] queue_backpressure_example:12.34; | pipelines.queue_backpressure_example=12.34;15;20 pipelines.example.output_throughput=0 pipelines.example.input_throughput=10 pipelines.example.filter_throughput=0
```

Fixes #71 