### PR TITLE
Remove status perfdata for health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage:
 Examples:
 
 	$ check_logstash health --hostname 'localhost' --port 8888 --insecure
-	[OK] - Logstash is healthy | status=green process.cpu.percent=0;0.5;3;0;100
+	[OK] - Logstash is healthy | process.cpu.percent=0;0.5;3;0;100
 	 \_[OK] Heap usage at 12.00%
 	 \_[OK] Open file descriptors at 12.00%
 	 \_[OK] CPU usage at 5.00%

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -92,9 +92,6 @@ func generatePerfdata(stat logstash.Stat, thres HealthThreshold) perfdata.Perfda
 	var l perfdata.PerfdataList
 
 	l.Add(&perfdata.Perfdata{
-		Label: "status",
-		Value: stat.Status})
-	l.Add(&perfdata.Perfdata{
 		Label: "process.cpu.percent",
 		Value: stat.Process.CPU.Percent,
 		Uom:   "%",

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -129,7 +129,7 @@ func TestHealthCmd_Logstash7(t *testing.T) {
 				w.Write([]byte(`{"host":"test","version":"7.17.8","status":"green","jvm":{"threads":{"count":50,"peak_count":51},"mem":{"heap_used_percent":20}},"process":{"open_file_descriptors": 120,"peak_open_file_descriptors": 120,"max_file_descriptors":16384,"cpu":{"percent": 1}}}`))
 			})),
 			args:     []string{"run", "../main.go", "health"},
-			expected: "| status=green process.cpu.percent=1%;100;100;0;100 jvm.mem.heap_used_percent=20%;70;80;0;100 jvm.threads.count=50;;;;0 process.open_file_descriptors=120;100;100;0;16384",
+			expected: "| process.cpu.percent=1%;100;100;0;100 jvm.mem.heap_used_percent=20%;70;80;0;100 jvm.threads.count=50;;;;0 process.open_file_descriptors=120;100;100;0;16384",
 		},
 		{
 			name: "health-red",
@@ -269,7 +269,7 @@ func TestHealthCmd_Logstash8(t *testing.T) {
 				w.Write([]byte(`{"host":"test","version":"8.6","status":"green","jvm":{"threads":{"count":50,"peak_count":51},"mem":{"heap_used_percent":20}},"process":{"open_file_descriptors": 120,"peak_open_file_descriptors": 120,"max_file_descriptors":16384,"cpu":{"percent": 1}}}`))
 			})),
 			args:     []string{"run", "../main.go", "health"},
-			expected: "| status=green process.cpu.percent=1%;100;100;0;100 jvm.mem.heap_used_percent=20%;70;80;0;100 jvm.threads.count=50;;;;0 process.open_file_descriptors=120;100;100;0;16384",
+			expected: "| process.cpu.percent=1%;100;100;0;100 jvm.mem.heap_used_percent=20%;70;80;0;100 jvm.threads.count=50;;;;0 process.open_file_descriptors=120;100;100;0;16384",
 		},
 		{
 			name: "health-cpu-heap-worst-state",


### PR DESCRIPTION
To avoid string data in the perfdata value.

I think it's best to just remove the data, we could try to convert it into a numerical value but that seems too much overhead.

See #84 