### PR TITLE
Set inflight events to zero if below zero

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -30,6 +30,18 @@ type PipelineThreshold struct {
 
 var cliPipelineConfig PipelineConfig
 
+// calculateInflightEvents calculates the current inflight events,
+// returns 0 if the value is negative.
+func calculateInflightEvents(in, out int) int {
+	r := in - out
+
+	if r < 0 {
+		return 0
+	}
+
+	return r
+}
+
 func parsePipeThresholds(config PipelineConfig) (PipelineThreshold, error) {
 	// Parses the CLI parameters
 	var t PipelineThreshold
@@ -107,7 +119,7 @@ var pipelineCmd = &cobra.Command{
 		var summary strings.Builder
 
 		for name, pipe := range pp.Pipelines {
-			inflightEvents := pipe.Events.In - pipe.Events.Out
+			inflightEvents := calculateInflightEvents(pipe.Events.In, pipe.Events.Out)
 
 			summary.WriteString("\n \\_")
 			if thresholds.Critical.DoesViolate(float64(inflightEvents)) {

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -9,6 +9,23 @@ import (
 	"testing"
 )
 
+func TestCalculateInflightEvents(t *testing.T) {
+	var actual int
+
+	actual = calculateInflightEvents(0, 10)
+
+	if actual != 0 {
+		t.Error("\nActual: ", actual, "\nExpected: ", 0)
+	}
+
+	actual = calculateInflightEvents(20, 10)
+
+	if actual != 10 {
+		t.Error("\nActual: ", actual, "\nExpected: ", 10)
+	}
+
+}
+
 func TestPipeline_ConnectionRefused(t *testing.T) {
 
 	cmd := exec.Command("go", "run", "../main.go", "pipeline", "--port", "9999", "--inflight-events-warn", "10", "--inflight-events-crit", "20")


### PR DESCRIPTION
 - Negative values are somewhat nonsensical and caused confusion

See #87 

See #28 

See #62 